### PR TITLE
feat: Implement a `formatCurrency()` Utility for Consistent Price Display (#45)

### DIFF
--- a/utils/formatCurrency.js
+++ b/utils/formatCurrency.js
@@ -1,15 +1,36 @@
 /**
- * Formats currencies
+ * Formats a numeric value into a currency string with thousand separators and
+ * fixed decimal places.
  *
- * TODO: Add documentation
+ * @param {number} amount - The numeric value to format
+ * @param {Object} options - Format options
+ * @param {string} [options.currency] - Currency code (e.g. "USD", "PKR"). When omitted, formats as a plain decimal.
+ * @param {number} [options.decimals=2] - Number of decimal places
+ * @param {string} [options.locale="en-US"] - Locale tag used for formatting (e.g. "en-GB", "ur-PK")
+ * @returns {string | null} - The formatted string, "0.00" for invalid input, or null for non-finite values (Infinity, -Infinity)
  */
 
-export function formatCurrency(amount, config = {}) {
-  const { currency, decimals } = config;
+export function formatCurrency(amount, options = {}) {
+  const { currency, decimals = 2, locale } = options;
 
-  // TODO: Complete implementation and make function robust.
+  const isCurrency = typeof currency === 'string' && currency.length > 0;
 
-  return new Intl.NumberFormat("en-US", {
-    currency,
-  }).format(amount);
+  if (isNaN(amount)) return '0.00';
+
+  // Infinity and -Infinity have no meaningful currency representation
+  if (!isFinite(amount)) return null;
+
+  try {
+    return new Intl.NumberFormat(locale || 'en-US', {
+      style: isCurrency ? 'currency' : 'decimal',
+      ...(isCurrency && { currency }),
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    }).format(amount);
+  } catch {
+    return new Intl.NumberFormat(locale || 'en-US', {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    }).format(amount);
+  }
 }


### PR DESCRIPTION
Closes #45

Changes:

- Adds a `formatCurrency()` utility for consistent price display which:
  - Accept a numeric value as input
  - Format numbers with:
    - Thousand separators (e.g., 1,000)
    - Fixed decimal places (default: 2)
  - Supports:
    - Currency symbols (USD, PKR, etc.)
    - Custom decimal precision