### PR TITLE
feat: implement rateLimit() utility for function call throttling

### DIFF
--- a/utils/rateLimit.js
+++ b/utils/rateLimit.js
@@ -1,0 +1,55 @@
+/**
+ * rateLimit - Restricts how many times a function can be called within an interval
+ *
+ * @param {Function} fn - The function to rate limit
+ * @param {Object} config - Configuration object
+ * @param {number} config.limit - Max number of calls allowed per interval
+ * @param {number} config.interval - Time window in milliseconds
+ * @returns {Function} - A rate-limited version of the input function
+ *
+ * @example
+ * const limitedFn = rateLimit(apiCall, { limit: 3, interval: 1000 });
+ * limitedFn(); // allowed
+ * limitedFn(); // allowed
+ * limitedFn(); // allowed
+ * limitedFn(); // throws Error('Rate limit exceeded')
+ */
+export function rateLimit(fn, config) {
+  if (typeof fn !== 'function') {
+    throw new TypeError('rateLimit: first argument must be a function');
+  }
+
+  if (!config || typeof config !== 'object') {
+    throw new TypeError('rateLimit: second argument must be a config object');
+  }
+
+  const { limit, interval } = config;
+
+  if (typeof limit !== 'number' || limit <= 0) {
+    throw new RangeError('rateLimit: limit must be a number greater than 0');
+  }
+
+  if (typeof interval !== 'number' || interval <= 0) {
+    throw new RangeError('rateLimit: interval must be a number greater than 0');
+  }
+
+  let callCount = 0;
+  let windowStart = Date.now();
+
+  return function rateLimited(...args) {
+    const now = Date.now();
+
+    // Reset counter if the interval window has passed
+    if (now - windowStart >= interval) {
+      callCount = 0;
+      windowStart = now;
+    }
+
+    if (callCount >= limit) {
+      throw new Error('Rate limit exceeded');
+    }
+
+    callCount++;
+    return fn.apply(this, args);
+  };
+}


### PR DESCRIPTION
## 🎯 Overview
Implements a reusable `rateLimit()` utility that restricts how many times a function can be called within a specified time interval. This is a common production pattern used to prevent API abuse, protect rate-limited endpoints, and control resource usage.

Closes #58 

## 🔧 Changes Made

### New File: `utils/rateLimit.js`
- Implemented `rateLimit(fn, config)` using a counter + timestamp window approach
- Resets call count automatically after the interval expires (lazy reset — no persistent timers)
- Preserves function context and arguments via `fn.apply(this, args)`
- Exported as a named ES6 export

### Edge Cases Handled
- Non-function input → throws `TypeError`
- Missing or invalid config object → throws `TypeError`
- `limit <= 0` → throws `RangeError`
- `interval <= 0` → throws `RangeError`
- Rapid consecutive calls exceeding limit → throws `Error('Rate limit exceeded')`

## 🧪 Testing
```javascript
const limitedFn = rateLimit(apiCall, { limit: 3, interval: 1000 });

// Within limit — all resolve normally
limitedFn(); // ✅ allowed
limitedFn(); // ✅ allowed
limitedFn(); // ✅ allowed
limitedFn(); // ❌ throws Error('Rate limit exceeded')

// After 1000ms interval resets — allowed again
setTimeout(() => limitedFn(), 1000); // ✅ allowed

// Edge cases
rateLimit('not-a-function', { limit: 3, interval: 1000 }); // TypeError
rateLimit(apiCall, null);                                   // TypeError
rateLimit(apiCall, { limit: 0, interval: 1000 });          // RangeError
rateLimit(apiCall, { limit: 3, interval: -1 });            // RangeError
