### PR TITLE
feat: add pLimit utility

### DIFF
--- a/examples/pLimitExample.js
+++ b/examples/pLimitExample.js
@@ -1,0 +1,26 @@
+const pLimit = require('../utils/pLimit');
+
+const limit = pLimit(2);
+
+const fetchData = async (id) => {
+  console.log(`Starting task ${id}`);
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 500);
+  });
+
+  console.log(`Finished task ${id}`);
+
+  return `Result ${id}`;
+};
+
+const tasks = [
+  () => fetchData(1),
+  () => fetchData(2),
+  () => fetchData(3),
+  () => fetchData(4)
+];
+
+Promise.all(tasks.map((task) => limit(task))).then((results) => {
+  console.log(results);
+});

--- a/tests/pLimit.test.js
+++ b/tests/pLimit.test.js
@@ -1,0 +1,99 @@
+const pLimit = require('../utils/pLimit');
+
+const delay = (value, time) => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve(value);
+  }, time);
+});
+
+async function testConcurrencyLimit() {
+  const limit = pLimit(2);
+  let activeCount = 0;
+  let maxActiveCount = 0;
+
+  const tasks = [1, 2, 3, 4].map((value) => limit(async () => {
+    activeCount += 1;
+    maxActiveCount = Math.max(maxActiveCount, activeCount);
+
+    const result = await delay(value, 50);
+
+    activeCount -= 1;
+    return result;
+  }));
+
+  const results = await Promise.all(tasks);
+
+  console.log(results);
+  console.log(maxActiveCount);
+}
+
+async function testSyncTask() {
+  const limit = pLimit(1);
+
+  const result = await limit(() => 'sync result');
+
+  console.log(result);
+}
+
+async function testRejectedTask() {
+  const limit = pLimit(1);
+
+  try {
+    await limit(() => Promise.reject(new Error('Task failed')));
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+
+async function testQueueContinuesAfterReject() {
+  const limit = pLimit(1);
+
+  const results = await Promise.allSettled([
+    limit(() => Promise.reject(new Error('First failed'))),
+    limit(() => Promise.resolve('second task completed'))
+  ]);
+
+  console.log(results[0].status);
+  console.log(results[1].value);
+}
+
+function testInvalidConcurrency() {
+  try {
+    pLimit(0);
+  } catch (error) {
+    console.log(error.message);
+  }
+
+  try {
+    pLimit(-1);
+  } catch (error) {
+    console.log(error.message);
+  }
+
+  try {
+    pLimit(1.5);
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+
+async function testInvalidTask() {
+  const limit = pLimit(1);
+
+  try {
+    await limit('not a function');
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+
+async function runTests() {
+  await testConcurrencyLimit();
+  await testSyncTask();
+  await testRejectedTask();
+  await testQueueContinuesAfterReject();
+  testInvalidConcurrency();
+  await testInvalidTask();
+}
+
+runTests();

--- a/utils/pLimit.js
+++ b/utils/pLimit.js
@@ -1,0 +1,53 @@
+/**
+ * Create a concurrency limiter for async or sync tasks.
+ *
+ * @param {number} concurrency Maximum number of tasks running at once.
+ * @returns {Function} Function used to schedule limited tasks.
+ */
+function pLimit(concurrency) {
+  if (
+    !Number.isInteger(concurrency) ||
+    concurrency < 1
+  ) {
+    throw new Error('Concurrency must be a positive integer');
+  }
+
+  const queue = [];
+  let activeCount = 0;
+
+  const next = () => {
+    if (activeCount >= concurrency || queue.length === 0) {
+      return;
+    }
+
+    const task = queue.shift();
+    activeCount += 1;
+
+    Promise.resolve()
+      .then(task.fn)
+      .then(task.resolve)
+      .catch(task.reject)
+      .finally(() => {
+        activeCount -= 1;
+        next();
+      });
+  };
+
+  return function limit(fn) {
+    if (typeof fn !== 'function') {
+      return Promise.reject(new Error('Task must be a function'));
+    }
+
+    return new Promise((resolve, reject) => {
+      queue.push({
+        fn,
+        resolve,
+        reject
+      });
+
+      next();
+    });
+  };
+}
+
+module.exports = pLimit;


### PR DESCRIPTION
Closes #69

## Summary
Added a `pLimit()` utility for limiting the number of concurrently running async tasks.

## Features Added
- Added `utils/pLimit.js`
- Added `tests/pLimit.test.js`
- Added `examples/pLimitExample.js`
- Supports configurable concurrency limits
- Uses a FIFO queue for pending tasks
- Tracks active task count internally
- Supports both sync and async task functions
- Handles rejected tasks properly
- Continues processing queued tasks after a rejection
- Validates invalid concurrency values
- Validates invalid task input

## Testing
Tested locally with:

```bash
node tests/pLimit.test.js
node examples/pLimitExample.js