### PR TITLE
feat: add duplicate request detection utility

### DIFF
--- a/tests/duplicateRequestDetector.test.js
+++ b/tests/duplicateRequestDetector.test.js
@@ -1,0 +1,218 @@
+'use strict';
+
+/**
+ * Tests for utils/DuplicateRequestDetector.js
+ *
+ * Run with: node tests/duplicateRequestDetector.test.js
+ */
+
+const DuplicateRequestDetector = require('../utils/DuplicateRequestDetector');
+
+let passed = 0;
+let failed = 0;
+
+const test = async (name, fn) => {
+  try {
+    await fn();
+    console.log(`  ✔  ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✘  ${name}`);
+    console.error(`       ${err.message}`);
+    failed++;
+  }
+};
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message || 'Assertion failed');
+};
+
+const assertEquals = (actual, expected, label = '') => {
+  if (actual !== expected) {
+    throw new Error(
+      `${label ? label + ': ' : ''}expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    );
+  }
+};
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function runAsyncTests() {
+  console.log('\nTTL expiration');
+
+  await test('allows the same request again after TTL expires', async () => {
+    const detector = new DuplicateRequestDetector({ ttl: 50 });
+
+    assertEquals(detector.isDuplicate('create-order-123'), false, 'first call');
+    assertEquals(detector.isDuplicate('create-order-123'), true, 'second call');
+
+    await delay(60);
+
+    assertEquals(detector.isDuplicate('create-order-123'), false, 'after ttl');
+  });
+
+  await test('removes expired entries from memory', async () => {
+    const detector = new DuplicateRequestDetector({ ttl: 50 });
+
+    detector.isDuplicate('order-1');
+    detector.isDuplicate('order-2');
+    assertEquals(detector.size(), 2, 'size before expiry');
+
+    await delay(60);
+
+    assertEquals(detector.size(), 0, 'size after expiry');
+  });
+
+  await test('cleans up expired entries during duplicate checks', async () => {
+    const detector = new DuplicateRequestDetector({ ttl: 50 });
+
+    detector.isDuplicate('cleanup-test');
+    assertEquals(detector.size(), 1, 'tracked before expiry');
+
+    await delay(60);
+    detector.isDuplicate('other-request');
+
+    assertEquals(detector.size(), 1, 'only active entry remains');
+    assert(detector.isDuplicate('cleanup-test') === false, 'expired id is not duplicate');
+  });
+}
+
+async function runSyncTests() {
+  console.log('\nBasic duplicate detection');
+
+  await test('returns false on first request and true on duplicate', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate('create-order-123'), false);
+    assertEquals(detector.isDuplicate('create-order-123'), true);
+  });
+
+  await test('tracks different request identifiers independently', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate('order-a'), false);
+    assertEquals(detector.isDuplicate('order-b'), false);
+    assertEquals(detector.isDuplicate('order-a'), true);
+    assertEquals(detector.isDuplicate('order-b'), true);
+  });
+
+  await test('supports numeric request identifiers', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate(42), false);
+    assertEquals(detector.isDuplicate(42), true);
+    assertEquals(detector.isDuplicate('42'), true);
+  });
+
+  console.log('\nTTL configuration');
+
+  await test('keeps entries without expiration when ttl is omitted', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate('persistent-id'), false);
+    assertEquals(detector.isDuplicate('persistent-id'), true);
+    assertEquals(detector.size(), 1, 'entry remains tracked');
+  });
+
+  await test('ignores invalid ttl values and keeps entries persistent', () => {
+    const detector = new DuplicateRequestDetector({ ttl: 0 });
+
+    assertEquals(detector.isDuplicate('no-ttl'), false);
+    assertEquals(detector.isDuplicate('no-ttl'), true);
+    assertEquals(detector.size(), 1, 'entry remains tracked');
+  });
+
+  console.log('\nInvalid inputs');
+
+  await test('returns false for null request id', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate(null), false);
+    assertEquals(detector.size(), 0, 'null is not tracked');
+  });
+
+  await test('returns false for undefined request id', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate(undefined), false);
+    assertEquals(detector.size(), 0, 'undefined is not tracked');
+  });
+
+  await test('returns false for empty request id', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate(''), false);
+    assertEquals(detector.size(), 0, 'empty string is not tracked');
+  });
+
+  await test('returns false for whitespace-only request id', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate('   '), false);
+    assertEquals(detector.size(), 0, 'whitespace id is not tracked');
+  });
+
+  await test('returns false for non-string non-number request ids', () => {
+    const detector = new DuplicateRequestDetector();
+
+    assertEquals(detector.isDuplicate({}), false);
+    assertEquals(detector.isDuplicate([]), false);
+    assertEquals(detector.isDuplicate(true), false);
+    assertEquals(detector.size(), 0, 'invalid ids are not tracked');
+  });
+
+  console.log('\nclear()');
+
+  await test('removes all tracked identifiers', () => {
+    const detector = new DuplicateRequestDetector();
+
+    detector.isDuplicate('order-1');
+    detector.isDuplicate('order-2');
+    assertEquals(detector.size(), 2, 'size before clear');
+
+    detector.clear();
+
+    assertEquals(detector.size(), 0, 'size after clear');
+    assertEquals(detector.isDuplicate('order-1'), false, 'order-1 allowed again');
+    assertEquals(detector.isDuplicate('order-2'), false, 'order-2 allowed again');
+  });
+
+  console.log('\nMemory management');
+
+  await test('does not grow memory for repeated invalid inputs', () => {
+    const detector = new DuplicateRequestDetector();
+
+    for (let i = 0; i < 1000; i++) {
+      detector.isDuplicate(null);
+      detector.isDuplicate('');
+    }
+
+    assertEquals(detector.size(), 0, 'invalid inputs are not stored');
+  });
+
+  await test('tracks many unique identifiers without throwing', () => {
+    const detector = new DuplicateRequestDetector({ ttl: 1000 });
+
+    for (let i = 0; i < 500; i++) {
+      assertEquals(detector.isDuplicate(`request-${i}`), false);
+    }
+
+    assertEquals(detector.size(), 500, 'all unique ids tracked');
+  });
+}
+
+async function main() {
+  await runSyncTests();
+  await runAsyncTests();
+
+  console.log(`\n${'─'.repeat(50)}`);
+  console.log(`  Results: ${passed} passed, ${failed} failed`);
+  console.log('─'.repeat(50));
+
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/utils/DuplicateRequestDetector.README.md
+++ b/utils/DuplicateRequestDetector.README.md
@@ -1,0 +1,108 @@
+# Duplicate Request Detector
+
+A lightweight utility that detects and blocks duplicate requests based on a unique request identifier and a configurable time window.
+
+---
+
+## Problem
+
+Duplicate requests are a common production issue:
+
+- Users double-clicking "Pay Now"
+- Repeated form submissions
+- Slow networks causing duplicate API calls
+- Duplicate order or email operations
+
+This utility helps prevent those mistakes without external dependencies.
+
+---
+
+## Installation
+
+No external libraries are required. Copy or require the module from `utils/DuplicateRequestDetector.js`.
+
+---
+
+## Basic Usage
+
+```javascript
+const DuplicateRequestDetector = require('./utils/DuplicateRequestDetector');
+
+const detector = new DuplicateRequestDetector();
+
+detector.isDuplicate('create-order-123'); // false
+detector.isDuplicate('create-order-123'); // true
+```
+
+---
+
+## With Expiration Window
+
+```javascript
+const detector = new DuplicateRequestDetector({ ttl: 5000 });
+
+detector.isDuplicate('create-order-123'); // false
+detector.isDuplicate('create-order-123'); // true
+
+// After 5 seconds, the same identifier can be processed again
+```
+
+---
+
+## Real-World Example
+
+```javascript
+if (detector.isDuplicate(orderId)) {
+  throw new Error('Duplicate request detected');
+}
+
+processOrder();
+```
+
+---
+
+## API
+
+### `new DuplicateRequestDetector(options?)`
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `ttl` | `number` | Optional TTL in milliseconds. When omitted, entries persist until `clear()` is called. |
+
+### `isDuplicate(requestId)`
+
+Returns `true` when the identifier was already seen within the active TTL window; otherwise records it and returns `false`.
+
+Supported identifier types: `string`, `number`.
+
+Invalid inputs (`null`, `undefined`, empty/whitespace strings, other types) return `false` and are not tracked.
+
+### `clear()`
+
+Removes all tracked identifiers.
+
+### `size()`
+
+Returns the number of active, non-expired tracked identifiers.
+
+---
+
+## Edge Cases
+
+- Empty, null, and invalid request IDs are handled gracefully
+- Expired entries are removed automatically
+- Memory is cleaned up during duplicate checks to avoid leaks
+
+---
+
+## Tests
+
+```bash
+node tests/duplicateRequestDetector.test.js
+```
+
+---
+
+## Related Issue
+
+Implements [#104](https://github.com/moizycodes/moizy-open-source-issues/issues/104).

--- a/utils/DuplicateRequestDetector.js
+++ b/utils/DuplicateRequestDetector.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/**
+ * Duplicate Request Detector
+ *
+ * Detects and blocks duplicate requests based on a unique request identifier
+ * and a configurable time-to-live (TTL) window. Useful for preventing double
+ * payments, duplicate form submissions, and repeated API calls.
+ *
+ * @example
+ * const DuplicateRequestDetector = require('./utils/DuplicateRequestDetector');
+ *
+ * const detector = new DuplicateRequestDetector({ ttl: 5000 });
+ *
+ * if (detector.isDuplicate(orderId)) {
+ *   throw new Error('Duplicate request detected');
+ * }
+ *
+ * processOrder();
+ */
+class DuplicateRequestDetector {
+  /**
+   * @param {Object} [options={}]
+   * @param {number} [options.ttl] - Time window in milliseconds during which
+   *   repeat identifiers are treated as duplicates. When omitted, entries do
+   *   not expire until {@link DuplicateRequestDetector#clear} is called.
+   */
+  constructor(options = {}) {
+    const ttl = options.ttl;
+
+    this.ttl =
+      typeof ttl === 'number' && ttl > 0 ? ttl : null;
+
+    /** @type {Map<string, number|null>} */
+    this.entries = new Map();
+  }
+
+  /**
+   * Checks whether a request identifier has already been seen within the TTL window.
+   *
+   * The first call for an identifier returns `false` (not a duplicate) and records
+   * the identifier. Subsequent calls with the same identifier return `true` until
+   * the entry expires or {@link DuplicateRequestDetector#clear} is invoked.
+   *
+   * @param {string|number} requestId - Unique identifier for the request
+   * @returns {boolean} `true` if the request is a duplicate, otherwise `false`
+   */
+  isDuplicate(requestId) {
+    if (!this.isValidRequestId(requestId)) {
+      return false;
+    }
+
+    this.removeExpiredEntries();
+
+    const key = String(requestId);
+    const now = Date.now();
+
+    if (this.entries.has(key)) {
+      const expiresAt = this.entries.get(key);
+
+      if (expiresAt === null || now < expiresAt) {
+        return true;
+      }
+
+      this.entries.delete(key);
+    }
+
+    const expiresAt = this.ttl !== null ? now + this.ttl : null;
+    this.entries.set(key, expiresAt);
+
+    return false;
+  }
+
+  /**
+   * Removes all tracked request identifiers.
+   */
+  clear() {
+    this.entries.clear();
+  }
+
+  /**
+   * Returns the number of active (non-expired) tracked identifiers.
+   *
+   * @returns {number}
+   */
+  size() {
+    this.removeExpiredEntries();
+    return this.entries.size;
+  }
+
+  /**
+   * @param {*} requestId
+   * @returns {boolean}
+   */
+  isValidRequestId(requestId) {
+    if (requestId === null || requestId === undefined) {
+      return false;
+    }
+
+    if (typeof requestId !== 'string' && typeof requestId !== 'number') {
+      return false;
+    }
+
+    if (typeof requestId === 'string' && requestId.trim() === '') {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Deletes expired entries to prevent unbounded memory growth.
+   */
+  removeExpiredEntries() {
+    if (this.ttl === null) {
+      return;
+    }
+
+    const now = Date.now();
+
+    for (const [key, expiresAt] of this.entries) {
+      if (expiresAt !== null && now >= expiresAt) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}
+
+module.exports = DuplicateRequestDetector;


### PR DESCRIPTION
Closes #104

## Description
Adds a production-ready `DuplicateRequestDetector` utility that detects and blocks duplicate requests using a unique request identifier and configurable TTL window.

### Changes
- `utils/DuplicateRequestDetector.js` — class with `isDuplicate()`, `clear()`, and `size()`
- Automatic expiry cleanup to prevent memory growth from stale entries
- Graceful handling of invalid inputs (null, empty string, non-string/number types)
- `utils/DuplicateRequestDetector.README.md` — usage and API documentation
- `tests/duplicateRequestDetector.test.js` — 16 unit tests covering duplicate detection, TTL expiration, invalid inputs, and memory cleanup

## Type of Change
- [x] New feature

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project code style
- [x] I have added tests/examples if applicable
- [x] I have linked the relevant issue number
- [x] My PR is self-contained and does not include unrelated changes

## Test plan
- [x] Run `node tests/duplicateRequestDetector.test.js` — 16 passed, 0 failed