### PR TITLE
feat: add file upload validator utility

### DIFF
--- a/tests/validateFile.test.js
+++ b/tests/validateFile.test.js
@@ -1,0 +1,78 @@
+const validateFile = require("../utils/validateFile");
+
+describe("validateFile", () => {
+  const validFile = {
+    name: "profile.png",
+    size: 204800,
+    type: "image/png",
+  };
+
+  test("accepts valid file", () => {
+    const result = validateFile(validFile, {
+      maxSize: 500000,
+      allowedTypes: ["image/png"],
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("rejects oversized file", () => {
+    const result = validateFile(validFile, {
+      maxSize: 1000,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "File size exceeds maximum limit"
+    );
+  });
+
+  test("rejects invalid mime type", () => {
+    const result = validateFile(validFile, {
+      allowedTypes: ["image/jpeg"],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "File type is not allowed"
+    );
+  });
+
+  test("rejects missing required file", () => {
+    const result = validateFile(null, {
+      required: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "File is required"
+    );
+  });
+
+  test("handles missing optional file", () => {
+    const result = validateFile(null);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("rejects invalid file object", () => {
+    const result = validateFile({});
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Invalid file object"
+    );
+  });
+
+  test("allows zero-byte file unless restricted", () => {
+    const result = validateFile({
+      name: "empty.png",
+      size: 0,
+      type: "image/png",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/utils/validateFile.js
+++ b/utils/validateFile.js
@@ -1,0 +1,79 @@
+/**
+ * Validates uploaded file metadata.
+ *
+ * @param {Object|null} file
+ * @param {Object} options
+ * @param {number} options.maxSize
+ * @param {string[]} options.allowedTypes
+ * @param {boolean} options.required
+ * @returns {{valid: boolean, errors: string[]}}
+ */
+function validateFile(file, options = {}) {
+  const {
+    maxSize,
+    allowedTypes,
+    required = false,
+  } = options;
+
+  const errors = [];
+
+  // Required file validation
+  if (!file) {
+    if (required) {
+      errors.push("File is required");
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  // File object validation
+  if (
+    typeof file !== "object" ||
+    file.size === undefined ||
+    file.type === undefined ||
+    file.name === undefined
+  ) {
+    return {
+      valid: false,
+      errors: ["Invalid file object"],
+    };
+  }
+  if (
+  typeof file !== 'object' ||
+  typeof file.name !== 'string' ||
+  typeof file.size !== 'number' ||
+  typeof file.type !== 'string'
+) {
+  return {
+    valid: false,
+    errors: ['Invalid file object']
+  };
+}
+
+  // File size validation
+  if (
+    typeof maxSize === "number" &&
+    file.size > maxSize
+  ) {
+    errors.push("File size exceeds maximum limit");
+  }
+
+  // MIME type validation
+  if (
+    Array.isArray(allowedTypes) &&
+    allowedTypes.length > 0 &&
+    !allowedTypes.includes(file.type)
+  ) {
+    errors.push("File type is not allowed");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+module.exports = validateFile;


### PR DESCRIPTION
Closes #107 

## Description

Adds a reusable and production-ready `validateFile` utility for validating uploaded file metadata before files are accepted by the application.

## Changes

* `utils/validateFile.js` — utility function for validating uploaded files
* Added file size validation using configurable `maxSize`
* Added MIME type validation using configurable `allowedTypes`
* Added required file validation using `required` option
* Gracefully handles missing files and invalid file objects
* Supports validation of zero-byte files without errors
* Returns structured validation results with detailed error messages
* `tests/validateFile.test.js` — unit tests covering valid uploads, file size limits, MIME type restrictions, missing files, invalid file objects, and zero-byte files

## Type of Change

* [x] New feature
* [x] Security improvement
* [x] Validation utility

## Checklist

* [x] I have read the CONTRIBUTING.md guidelines
* [x] My code follows the project code style
* [x] I have added tests/examples if applicable
* [x] I have linked the relevant issue number
* [x] My PR is self-contained and does not include unrelated changes

## Test Plan

Run:

```bash
npx jest tests/validateFile.test.js
```

Result:

```text
PASS tests/validateFile.test.js

Tests: 7 passed, 0 failed
Test Suites: 1 passed, 1 total
```
