### PR TITLE
feat: add groupBy utility

### DIFF
--- a/examples/groupByExample.js
+++ b/examples/groupByExample.js
@@ -1,0 +1,15 @@
+const groupBy = require('../utils/groupBy');
+
+const products = [
+  { name: 'Laptop', category: 'electronics' },
+  { name: 'Phone', category: 'electronics' },
+  { name: 'Shirt', category: 'clothing' }
+];
+
+const groupedByCategory = groupBy(products, 'category');
+
+console.log(groupedByCategory);
+
+const groupedByCallback = groupBy(products, (product) => product.category);
+
+console.log(groupedByCallback);

--- a/tests/groupBy.test.js
+++ b/tests/groupBy.test.js
@@ -1,0 +1,34 @@
+const groupBy = require('../utils/groupBy');
+
+const users = [
+  { name: 'Ali', role: 'admin' },
+  { name: 'Moeez', role: 'user' },
+  { name: 'Ahmed', role: 'admin' }
+];
+
+console.log(groupBy(users, 'role'));
+
+console.log(groupBy(users, (user) => user.role));
+
+console.log(groupBy([], 'role'));
+
+console.log(groupBy(null, 'role'));
+
+console.log(groupBy(users, 'missing'));
+
+const mixedItems = [
+  { value: 1, type: 'number' },
+  { value: 'hello', type: 'string' },
+  { value: true, type: 'boolean' }
+];
+
+console.log(groupBy(mixedItems, 'type'));
+
+const callbackUndefined = [
+  { name: 'Item 1' },
+  { name: 'Item 2' }
+];
+
+console.log(groupBy(callbackUndefined, () => undefined));
+
+console.log(users);

--- a/utils/groupBy.js
+++ b/utils/groupBy.js
@@ -1,0 +1,34 @@
+/**
+ * Groups an array of items by a key or callback function.
+ *
+ * @param {Array} array
+ * @param {string|Function} keyOrFn
+ * @returns {Object}
+ */
+function groupBy(array, keyOrFn) {
+  if (!Array.isArray(array)) {
+    return {};
+  }
+
+  if (typeof keyOrFn !== 'string' && typeof keyOrFn !== 'function') {
+    return {};
+  }
+
+  return array.reduce((result, item) => {
+    const groupKey = typeof keyOrFn === 'function'
+      ? keyOrFn(item)
+      : item && item[keyOrFn];
+
+    const normalizedKey = String(groupKey);
+
+    if (!result[normalizedKey]) {
+      result[normalizedKey] = [];
+    }
+
+    result[normalizedKey].push(item);
+
+    return result;
+  }, {});
+}
+
+module.exports = groupBy;


### PR DESCRIPTION
## Summary
- Added a reusable `groupBy()` utility for grouping array items by a key or callback function
- Added tests for key-based grouping, callback-based grouping, empty arrays, invalid input, missing keys, callback returning undefined, and mixed data types
- Added an example file showing common usage

## Testing
- `node tests/groupBy.test.js`
- `node examples/groupByExample.js`

Closes #63