### PR TITLE
feat: add flattenObject utility

### DIFF
--- a/examples/flattenObjectExample.js
+++ b/examples/flattenObjectExample.js
@@ -1,0 +1,18 @@
+const flattenObject = require('../utils/flattenObject');
+
+const apiResponse = {
+  user: {
+    id: 1,
+    profile: {
+      name: 'Naveen',
+      location: {
+        city: 'Kingston',
+        country: 'Canada'
+      }
+    }
+  }
+};
+
+const flattened = flattenObject(apiResponse);
+
+console.log(flattened);

--- a/tests/flattenObject.test.js
+++ b/tests/flattenObject.test.js
@@ -1,0 +1,54 @@
+const flattenObject = require('../utils/flattenObject');
+
+const nestedUser = {
+  user: {
+    name: 'Moeez',
+    address: {
+      city: 'Lahore'
+    }
+  }
+};
+
+console.log(flattenObject(nestedUser));
+
+console.log(flattenObject({}));
+
+console.log(flattenObject(null));
+
+console.log(flattenObject('invalid'));
+
+console.log(flattenObject({
+  a: {
+    b: {
+      c: 1
+    }
+  }
+}));
+
+console.log(flattenObject({
+  user: {
+    name: 'Ali',
+    age: 25,
+    active: true,
+    address: null
+  }
+}));
+
+console.log(flattenObject({
+  product: {
+    name: 'Laptop',
+    tags: ['electronics', 'computer'],
+    price: 1200
+  }
+}));
+
+const originalObject = {
+  settings: {
+    theme: {
+      color: 'dark'
+    }
+  }
+};
+
+console.log(flattenObject(originalObject));
+console.log(originalObject);

--- a/utils/flattenObject.js
+++ b/utils/flattenObject.js
@@ -1,0 +1,39 @@
+/**
+ * Flattens a nested object into a single-level object using dot notation.
+ *
+ * @param {Object} obj
+ * @param {string} prefix
+ * @returns {Object}
+ */
+function flattenObject(obj, prefix = '') {
+  if (
+    obj === null ||
+    typeof obj !== 'object' ||
+    Array.isArray(obj)
+  ) {
+    return {};
+  }
+
+  return Object.keys(obj).reduce((result, key) => {
+    const value = obj[key];
+    const newKey = prefix ? `${prefix}.${key}` : key;
+
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      return {
+        ...result,
+        ...flattenObject(value, newKey)
+      };
+    }
+
+    return {
+      ...result,
+      [newKey]: value
+    };
+  }, {});
+}
+
+module.exports = flattenObject;


### PR DESCRIPTION
## Summary
- Added a `flattenObject()` utility for converting nested objects into dot notation keys
- Added tests for empty objects, non-object input, null values, deep nesting, mixed data types, arrays, and original object preservation
- Added an example file showing common API response flattening usage

## Testing
- `node tests/flattenObject.test.js`
- `node examples/flattenObjectExample.js`

Closes #65

Note: I noticed this issue had an earlier assignee, but there was no active PR linked. I’m happy to adjust or close this PR if the maintainer prefers to continue with the original assignee.