### PR TITLE
feat: add get utility

### DIFF
--- a/examples/getExample.js
+++ b/examples/getExample.js
@@ -1,0 +1,15 @@
+const get = require('../utils/get');
+
+const apiResponse = {
+  user: {
+    profile: {
+      address: {
+        city: 'Kingston'
+      }
+    }
+  }
+};
+
+console.log(get(apiResponse, 'user.profile.address.city'));
+console.log(get(apiResponse, 'user.profile.age', 25));
+console.log(get(apiResponse, ['user', 'profile', 'address', 'city']));

--- a/tests/get.test.js
+++ b/tests/get.test.js
@@ -1,0 +1,43 @@
+const get = require('../utils/get');
+
+const user = {
+  profile: {
+    address: {
+      city: 'Lahore'
+    },
+    age: 22,
+    active: false
+  }
+};
+
+console.log(get(user, 'profile.address.city'));
+
+console.log(get(user, 'profile.age'));
+
+console.log(get(user, 'profile.active'));
+
+console.log(get(user, 'profile.missing', 'default'));
+
+console.log(get(user, ['profile', 'address', 'city']));
+
+console.log(get(null, 'profile.address.city', 'not found'));
+
+console.log(get(undefined, 'profile.address.city', 'not found'));
+
+console.log(get({}, 'a.b.c', 'default'));
+
+console.log(get(user, '', 'empty path'));
+
+console.log(get(user, null, 'invalid path'));
+
+console.log(get(user, 'profile.address.country'));
+
+const originalUser = {
+  profile: {
+    name: 'Naveen'
+  }
+};
+
+get(originalUser, 'profile.name');
+
+console.log(originalUser);

--- a/utils/get.js
+++ b/utils/get.js
@@ -1,0 +1,33 @@
+/**
+ * Safely retrieves a nested value from an object using a string or array path.
+ *
+ * @param {Object} obj
+ * @param {string|string[]} path
+ * @param {*} defaultValue
+ * @returns {*}
+ */
+function get(obj, path, defaultValue) {
+  if (obj === null || obj === undefined || typeof obj !== 'object') {
+    return defaultValue;
+  }
+
+  if (path === '' || path === null || path === undefined) {
+    return defaultValue;
+  }
+
+  const keys = Array.isArray(path)
+    ? path
+    : String(path).split('.');
+
+  const result = keys.reduce((currentValue, key) => {
+    if (currentValue === null || currentValue === undefined) {
+      return undefined;
+    }
+
+    return currentValue[key];
+  }, obj);
+
+  return result === undefined ? defaultValue : result;
+}
+
+module.exports = get;


### PR DESCRIPTION
## Summary
- Added a `get()` utility for safe nested object property access
- Added support for string paths and array paths
- Added default fallback value handling
- Added tests for invalid object input, empty path, missing keys, null/undefined values, false values, and original object preservation
- Added an example file showing API response access usage

## Testing
- `node tests/get.test.js`
- `node examples/getExample.js`

Closes #70

Note: I noticed this issue had an earlier assignee, but there was no active PR linked. I’m happy to adjust or close this PR if the maintainer prefers to continue with the original assignee.