### PR TITLE
feat: add deepEqual utility

### DIFF
--- a/examples/deepEqualExample.js
+++ b/examples/deepEqualExample.js
@@ -1,0 +1,28 @@
+const deepEqual = require('../utils/deepEqual');
+
+const firstUser = {
+  id: 1,
+  profile: {
+    name: 'Naveen',
+    skills: ['JavaScript', 'Git']
+  }
+};
+
+const secondUser = {
+  id: 1,
+  profile: {
+    name: 'Naveen',
+    skills: ['JavaScript', 'Git']
+  }
+};
+
+const thirdUser = {
+  id: 1,
+  profile: {
+    name: 'Naveen',
+    skills: ['Git', 'JavaScript']
+  }
+};
+
+console.log(deepEqual(firstUser, secondUser));
+console.log(deepEqual(firstUser, thirdUser));

--- a/tests/deepEqual.test.js
+++ b/tests/deepEqual.test.js
@@ -1,0 +1,60 @@
+const deepEqual = require('../utils/deepEqual');
+
+console.log(deepEqual(1, 1));
+
+console.log(deepEqual(1, '1'));
+
+console.log(deepEqual('a', 'a'));
+
+console.log(deepEqual(null, null));
+
+console.log(deepEqual(null, undefined));
+
+console.log(deepEqual({}, {}));
+
+console.log(deepEqual([], []));
+
+console.log(deepEqual([1, 2, 3], [1, 2, 3]));
+
+console.log(deepEqual([1, 2], [2, 1]));
+
+console.log(deepEqual(
+  { a: 1, b: { c: 2 } },
+  { a: 1, b: { c: 2 } }
+));
+
+console.log(deepEqual(
+  { a: 1, b: { c: 2 } },
+  { a: 1, b: { c: 3 } }
+));
+
+console.log(deepEqual(
+  { user: { name: 'Naveen', roles: ['student', 'developer'] } },
+  { user: { name: 'Naveen', roles: ['student', 'developer'] } }
+));
+
+console.log(deepEqual(
+  { user: { name: 'Naveen', roles: ['developer', 'student'] } },
+  { user: { name: 'Naveen', roles: ['student', 'developer'] } }
+));
+
+const firstFunction = () => true;
+const secondFunction = () => true;
+
+console.log(deepEqual(firstFunction, firstFunction));
+
+console.log(deepEqual(firstFunction, secondFunction));
+
+const originalObject = {
+  a: {
+    b: 1
+  }
+};
+
+deepEqual(originalObject, {
+  a: {
+    b: 1
+  }
+});
+
+console.log(originalObject);

--- a/utils/deepEqual.js
+++ b/utils/deepEqual.js
@@ -1,0 +1,74 @@
+/**
+ * Compares two values to check whether they are deeply equal.
+ *
+ * @param {*} a
+ * @param {*} b
+ * @returns {boolean}
+ */
+function deepEqual(a, b) {
+  if (a === b) {
+    return true;
+  }
+
+  if (a === null || b === null) {
+    return a === b;
+  }
+
+  if (typeof a !== typeof b) {
+    return false;
+  }
+
+  if (typeof a !== 'object') {
+    return false;
+  }
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return compareArrays(a, b);
+  }
+
+  return compareObjects(a, b);
+}
+
+/**
+ * Compares two arrays recursively.
+ *
+ * @param {Array} a
+ * @param {Array} b
+ * @returns {boolean}
+ */
+function compareArrays(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return false;
+  }
+
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((item, index) => {
+    return deepEqual(item, b[index]);
+  });
+}
+
+/**
+ * Compares two objects recursively.
+ *
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {boolean}
+ */
+function compareObjects(a, b) {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  return keysA.every((key) => {
+    return Object.prototype.hasOwnProperty.call(b, key) &&
+      deepEqual(a[key], b[key]);
+  });
+}
+
+module.exports = deepEqual;


### PR DESCRIPTION
## Summary
- Added a `deepEqual()` utility for deep comparison of primitives, arrays, and objects
- Added recursive comparison for nested objects and arrays
- Added tests for primitives, type differences, null/undefined, empty objects, empty arrays, nested structures, arrays, and functions
- Added an example file showing object comparison usage

## Testing
- `node tests/deepEqual.test.js`
- `node examples/deepEqualExample.js`

Closes #68

Note: I noticed this issue had an earlier assignee, but there was no active PR linked. I’m happy to adjust or close this PR if the maintainer prefers to continue with the original assignee.