### PR TITLE
Fix: Convert tests and utils files to CommonJS to resolve SyntaxError…

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1,7 +1,7 @@
 // src/services/apiServices.js
-import { NetworkError, ServerError, handleError } from "../utils/errorHandler";
+const { NetworkError, ServerError, handleError } = require("../utils/errorHandler");
 
-export const fetchData = async (url) => {
+const fetchData = async (url) => {
     try {
         const response = await fetch(url);
 
@@ -21,3 +21,5 @@ export const fetchData = async (url) => {
         }
     }
 };
+
+module.exports = fetchData;

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,4 +1,4 @@
-export function debounce(fn, delay) {
+function debounce(fn, delay) {
   let timer;
   const debounced = function (...args) {
     clearTimeout(timer);
@@ -7,3 +7,5 @@ export function debounce(fn, delay) {
   debounced.cancel = () => clearTimeout(timer);
   return debounced;
 }
+
+module.exports = debounce;

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -48,4 +48,4 @@ const handleError = (error) => {
     return userMessage;
 };
 
-export { NetworkError, ServerError, ValidationError, handleError };
+module.exports = { NetworkError, ServerError, ValidationError, handleError };

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -20,7 +20,7 @@ const createError = (message) => ({
  * @param {*} value - The input value.
  * @returns {{ valid: boolean, message: string }}
  */
-export const validateRequired = (value) => {
+const validateRequired = (value) => {
     // Coerce to string if possible, then check for emptiness after trimming
     if (value === null || value === undefined || (typeof value === 'string' && value.trim() === "")) {
         return createError("This field is required.");
@@ -33,7 +33,7 @@ export const validateRequired = (value) => {
  * @param {string} value - The input value.
  * @returns {{ valid: boolean, message: string }}
  */
-export const validateEmail = (value) => {
+const validateEmail = (value) => {
     // Simple regex pattern for email format check
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; 
 
@@ -53,7 +53,7 @@ export const validateEmail = (value) => {
  * @param {number} [minLength=8] - The minimum required length.
  * @returns {{ valid: boolean, message: string }}
  */
-export const validatePassword = (value, minLength = 8) => {
+const validatePassword = (value, minLength = 8) => {
     if (!value) return VALID_RESULT;
     
     if (String(value).length < minLength) {
@@ -68,7 +68,7 @@ export const validatePassword = (value, minLength = 8) => {
  * @param {*} value - The input value.
  * @returns {{ valid: boolean, message: string }}
  */
-export const validateNumber = (value) => {
+const validateNumber = (value) => {
     // Skip if empty
     if (value === "" || value === null || value === undefined) return VALID_RESULT;
 
@@ -94,7 +94,7 @@ export const validateNumber = (value) => {
  * @param {Array<Function>} rules - An array of validation functions (or partially applied functions) to run.
  * @returns {{ valid: boolean, message: string }}
  */
-export function validateField(value, rules) {
+function validateField(value, rules) {
     if (!Array.isArray(rules)) {
         console.error("validateField requires an array of rules.");
         return VALID_RESULT;
@@ -115,3 +115,5 @@ export function validateField(value, rules) {
     // If all rules passed, return the success result
     return VALID_RESULT;
 }
+
+module.exports = {validateRequired, validateEmail, validatePassword, validateNumber, validateField};

--- a/tests/capitalize.test.js
+++ b/tests/capitalize.test.js
@@ -1,5 +1,8 @@
-import { test, assertEquals, assertThrows, printSummary } from "./test-utils.js";
-import { capitalize } from "../utils/capitalize.js";
+// import { test, assertEquals, assertThrows, printSummary } from "./test-utils.js";
+// import { capitalize } from "../utils/capitalize.js";
+
+const { test, assertEquals, assertThrows, printSummary } = require('./test-utils.js');
+const capitalize = require('../utils/capitalize.js');
 
 // Normal string
 test("capitalize normal string", () => {

--- a/tests/deepFreeze.test.js
+++ b/tests/deepFreeze.test.js
@@ -1,5 +1,5 @@
-import { test, assertEquals, assert, printSummary } from './test-utils.js';
-import { deepFreeze } from '../utils/deepFreeze.js';
+const { test, assertEquals, assert, printSummary } = require('./test-utils.js');
+const { deepFreeze } = require('../utils/deepFreeze.js');
 
 // Basic nested object freeze
 test('deepFreeze freezes nested objects', () => {

--- a/tests/functional.test.js
+++ b/tests/functional.test.js
@@ -1,12 +1,11 @@
 /**
  * Tests for utils/functional.js
  *
- * Run with: node --experimental-vm-modules tests/functional.test.js
- * (or through any bundler / test runner that supports ES modules)
+ * Run with: node tests/functional.test.js
  */
 
-import { test, assertEquals, assertThrows, printSummary } from "./test-utils.js";
-import { pipe, compose } from "../utils/functional.js";
+const { test, assertEquals, assertThrows, printSummary } = require("./test-utils.js");
+const { pipe, compose } = require("../utils/functional.js");
 
 test("pipe should apply functions from left to right", () => {
   const add = (x) => x + 1;

--- a/tests/once_test.js
+++ b/tests/once_test.js
@@ -1,4 +1,4 @@
-import { once } from "../utils/once";
+const once = require("../utils/once");
 
 test("once should only call function once", () => {
   let count = 0;

--- a/tests/sleep.test.js
+++ b/tests/sleep.test.js
@@ -1,9 +1,9 @@
-import { sleep } from "../utils/sleep.js";
-import {
+const sleep = require("../utils/sleep.js");
+const {
   test,
   assertEquals,
   printSummary,
-} from "./test-utils.js";
+} = require("./test-utils.js");
 
 // Valid delay
 test("sleep resolves after delay", async () => {

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -4,7 +4,7 @@
  * Provides functions to define tests, make assertions, and print a summary of results.
  *
  * Usage:
- * import { test, assertEquals, printSummary } from "./test-utils.js";
+ * const { test, assertEquals, printSummary } = require('./test-utils.js');
  *
  * test("example test", () => {
  *     assertEquals(1 + 1, 2);
@@ -16,7 +16,7 @@
 let passed = 0;
 let failed = 0;
 
-export const test = (name, fn) => {
+const test = (name, fn) => {
   try {
     fn();
     console.log(`✓ ${name}`);
@@ -28,11 +28,11 @@ export const test = (name, fn) => {
   }
 };
 
-export const assert = (condition, message) => {
+const assert = (condition, message) => {
   if (!condition) throw new Error(message || "Assertion failed");
 };
 
-export const assertEquals = (actual, expected, label = "") => {
+const assertEquals = (actual, expected, label = "") => {
   if (actual !== expected) {
     throw new Error(
       `${label ? label + ": " : ""}expected ${JSON.stringify(expected)}, ` +
@@ -41,7 +41,7 @@ export const assertEquals = (actual, expected, label = "") => {
   }
 };
 
-export const assertErrorExists = (errors, field, partialMessage) => {
+const assertErrorExists = (errors, field, partialMessage) => {
   const match = errors.find(
     (err) =>
       err.field === field && err.message.includes(partialMessage.toLowerCase()),
@@ -54,7 +54,7 @@ export const assertErrorExists = (errors, field, partialMessage) => {
   }
 };
 
-export const assertThrows = (fn, partialMessage = "") => {
+const assertThrows = (fn, partialMessage = "") => {
   try {
     fn();
     throw new Error("Expected function to throw, but it did not");
@@ -68,9 +68,11 @@ export const assertThrows = (fn, partialMessage = "") => {
   }
 };
 
-export const printSummary = () => {
+const printSummary = () => {
   console.log("\n" + "─".repeat(50));
   console.log(`Results: ${passed} passed, ${failed} failed`);
   console.log("─".repeat(50));
   if (failed > 0) process.exit(1);
 };
+
+module.exports = {test, assert, assertEquals, assertErrorExists, assertThrows, printSummary};

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -6,7 +6,7 @@
  * (or through any bundler / test runner that supports ES modules)
  */
 
-import { validate } from '../utils/validate.js';
+const validate = require('../utils/validate.js');
 
 // ---------------------------------------------------------------------------
 // Minimal test runner

--- a/utils/capitalize.js
+++ b/utils/capitalize.js
@@ -17,7 +17,7 @@
  * capitalize("");           // ""
  * capitalize("A");          // "A"
  */
-export function capitalize(str) {
+function capitalize(str) {
   // Handle non-string input gracefully
   if (typeof str !== "string") {
     throw new TypeError(`capitalize() expects a string, got ${typeof str}`);
@@ -29,3 +29,5 @@ export function capitalize(str) {
   // Uppercase first character, leave the rest unchanged
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+module.exports = capitalize;

--- a/utils/debounce.js
+++ b/utils/debounce.js
@@ -6,7 +6,7 @@
  * since it was last called.
  */
 
-export function debounce(fn, delay) {
+function debounce(fn, delay) {
   let timer;
 
   return function (...args) {
@@ -19,3 +19,5 @@ export function debounce(fn, delay) {
     }, delay);
   };
 }
+
+module.exports = debounce;

--- a/utils/deepClone.js
+++ b/utils/deepClone.js
@@ -21,7 +21,7 @@
  * const cloned = deepClone(obj);
  * console.log(cloned.self === cloned); // true
  */
-export function deepClone(value) {
+function deepClone(value) {
     return _clone(value, new WeakMap());
 }
 
@@ -64,3 +64,5 @@ function _clone(value, seen) {
 
     return clone;
 }
+
+module.exports = deepClone;

--- a/utils/deepFreeze.js
+++ b/utils/deepFreeze.js
@@ -28,7 +28,7 @@
  *
  * data.users[0].name = 'Bob'; // fails silently in non-strict mode
  */
-export function deepFreeze(obj) {
+function deepFreeze(obj) {
   return _freeze(obj, new WeakSet());
 }
 
@@ -70,4 +70,4 @@ function _freeze(obj, seen) {
   return Object.freeze(obj);
 }
 
-
+module.exports = deepFreeze;

--- a/utils/functional.js
+++ b/utils/functional.js
@@ -21,7 +21,7 @@
  * pipe(3, add, double); // throws TypeError: pipe: argument at index 0 is not a function, got number
  */
 
-export function pipe(...fns) {
+function pipe(...fns) {
   fns.forEach((f, i) => {
     if (typeof f !== "function")
       throw new TypeError(
@@ -34,7 +34,7 @@ export function pipe(...fns) {
   return (x) => fns.reduce((v, f) => f(v), x);
 }
 
-export function compose(...fns) {
+function compose(...fns) {
   fns.forEach((f, i) => {
     if (typeof f !== "function")
       throw new TypeError(
@@ -46,3 +46,5 @@ export function compose(...fns) {
 
   return (x) => fns.reduceRight((v, f) => f(v), x);
 }
+
+module.exports = {pipe, compose};

--- a/utils/once.js
+++ b/utils/once.js
@@ -4,7 +4,7 @@
  * @returns {Function} - New function that executes func only on first call 
  */
 
-export function once(func) {
+function once(func) {
   // Track if the function has been called
   let called = false;
 
@@ -26,3 +26,5 @@ export function once(func) {
     return result;
   };
 }
+
+module.exports = once;

--- a/utils/sleep.js
+++ b/utils/sleep.js
@@ -4,7 +4,7 @@
  * Delays execution for a specified amount of time.
  */
 
-export function sleep(ms) {
+function sleep(ms) {
   const delay =
     typeof ms === "number" && ms > 0
       ? ms
@@ -14,3 +14,5 @@ export function sleep(ms) {
     setTimeout(resolve, delay);
   });
 }
+
+module.exports = sleep;

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -159,7 +159,7 @@ const validateField = (field, value, fieldSchema) => {
  * //   ]
  * // }
  */
-export function validate(schema, data) {
+function validate(schema, data) {
   if (!schema || typeof schema !== "object") {
     return { isValid: true, errors: [] };
   }
@@ -181,3 +181,5 @@ export function validate(schema, data) {
     errors,
   };
 }
+
+module.exports = validate;

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -8,7 +8,7 @@ const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@$!%*#?&]{8,}$/
  * @param {any} value 
  * @returns {object}
  */
-export const validateRequired = (value) => {
+const validateRequired = (value) => {
   if (value === null || value === undefined || value === '') {
     return {
       valid: false,
@@ -35,7 +35,7 @@ export const validateRequired = (value) => {
  * @returns {object}
  */
 
-export const validateEmail = (email) => {
+const validateEmail = (email) => {
   if (!EMAIL_REGEX.test(email)) {
     return {
       valid: false,
@@ -57,7 +57,7 @@ export const validateEmail = (email) => {
  */
 
 
-export const validatePassword = (password) => {
+const validatePassword = (password) => {
   if (!PASSWORD_REGEX.test(password)) {
     return {
       valid: false,
@@ -76,7 +76,7 @@ export const validatePassword = (password) => {
  * @returns 
  */
 
-export const validateNumber = (value) => {
+const validateNumber = (value) => {
   if (isNaN(Number(value))) {
     return { valid: false, message: 'Please enter a valid number.' };
   }
@@ -102,7 +102,7 @@ const ruleRegistry = {
  * @returns {object}
  */
 
-export const validateField = (value, rules = []) => {
+const validateField = (value, rules = []) => {
   for (const rule of rules) {
     let ruleName = rule;
     
@@ -127,14 +127,14 @@ export const validateField = (value, rules = []) => {
 
 // Validation utility functions
 
-export const validateRequired = (value) => {
+const validateRequired = (value) => {
   if (!value || value.trim() === "") {
     return { valid: false, message: "This field is required" };
   }
   return { valid: true, message: "" };
 };
 
-export const validateEmail = (value) => {
+const validateEmail = (value) => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(value)) {
     return { valid: false, message: "Invalid email format" };
@@ -142,7 +142,7 @@ export const validateEmail = (value) => {
   return { valid: true, message: "" };
 };
 
-export const validatePassword = (value) => {
+const validatePassword = (value) => {
   if (value.length < 8) {
     return {
       valid: false,
@@ -176,14 +176,14 @@ export const validatePassword = (value) => {
   return { valid: true, message: "" };
 };
 
-export const validateNumber = (value) => {
+const validateNumber = (value) => {
   if (isNaN(value) || value === "") {
     return { valid: false, message: "Must be a valid number" };
   }
   return { valid: true, message: "" };
 };
 
-export const validateField = (value, rules) => {
+const validateField = (value, rules) => {
   for (const rule of rules) {
     const result = rule(value);
     if (!result.valid) {
@@ -193,3 +193,6 @@ export const validateField = (value, rules) => {
   return { valid: true, message: "" };
 };
 // >>>>>>> main
+
+module.exports = {validateRequired, validateEmail, validatePassword, validateNumber, validateField, 
+                  validateRequired, validateEmail, validatePassword, validateNumber, validateField};


### PR DESCRIPTION
### Description
Converted the test files and utility files from ES Module syntax (`import`/`export`) to standard CommonJS (`require`/`module.exports`). This resolves the local `SyntaxError: Cannot use import statement outside a module` crash and ensures consistency with the rest of the project's CommonJS configuration.

Closes #139
