### PR TITLE
Feature: Build a Git Ignore Generator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ Custom fields can be added when needed:
 maskSensitiveData(user, ['salary', 'nationalId']);
 ```
 
+### .gitignore Generator
+
+Use `gitignore-generator/gitignore.js` to generate a ready-to-use `.gitignore` file for one or more technologies (Node.js, React, Next.js, Express.js, VS Code, JetBrains IDEs, Python, Docker, Laravel, Flutter, Android, Go, Rust, Java).
+
+```bash
+node gitignore-generator/gitignore.js node react vscode
+```
+
+See `gitignore-generator/README.md` for full usage and supported technologies.
+
 ---
 
 ✅ Issue Guidelines

--- a/gitignore-generator/README.md
+++ b/gitignore-generator/README.md
@@ -1,0 +1,68 @@
+# .gitignore Generator
+
+A dependency-free CLI that generates a ready-to-use `.gitignore` file for one or more technologies, so you don't have to search for the right ignore rules every time you start a project.
+
+## Usage
+
+```bash
+node gitignore.js <technology> [technology...]
+```
+
+### Example
+
+```bash
+node gitignore.js node react vscode
+```
+
+Creates a `.gitignore` in the current directory, merging the rules for Node.js, React, and VS Code with no duplicate lines.
+
+## Supported technologies
+
+| Slug | Aliases | Display name |
+|---|---|---|
+| `node` | `nodejs` | Node.js |
+| `react` | — | React |
+| `nextjs` | `next` | Next.js |
+| `express` | `expressjs` | Express.js |
+| `vscode` | `vs-code` | VS Code |
+| `jetbrains` | `intellij` | JetBrains IDEs |
+| `python` | `py` | Python |
+| `docker` | — | Docker |
+| `laravel` | — | Laravel |
+| `flutter` | — | Flutter |
+| `android` | — | Android |
+| `go` | `golang` | Go |
+| `rust` | — | Rust |
+| `java` | — | Java |
+
+Technology names are case-insensitive.
+
+## Behavior
+
+- **Merging:** rules from each requested technology are combined; any line already added by an earlier technology is skipped, so the output has no duplicate entries.
+- **Duplicate arguments:** `node gitignore.js node node react` is treated the same as `node gitignore.js node react`.
+- **Existing `.gitignore`:** if one already exists in the current directory, it is overwritten.
+- **Unsupported technology:** printed as a warning (`Unsupported technology: <name>`) and skipped; the file is still generated for any valid technologies in the same command.
+- **No arguments:** prints usage instructions and exits with a non-zero status.
+- **All technologies unsupported:** prints a warning for each and exits with a non-zero status without writing a file.
+
+## Project layout
+
+```
+gitignore-generator/
+├── gitignore.js          # CLI entry point
+├── lib/
+│   ├── technologies.js   # slug/alias resolution + template loading
+│   └── generate.js       # merges technologies into deduped .gitignore content
+├── templates/            # one .txt file per supported technology
+├── tests/                # node:test suite
+└── README.md
+```
+
+## Testing
+
+Tests use Node's built-in test runner, so no extra dependencies are required:
+
+```bash
+node --test gitignore-generator/tests/*.test.js
+```

--- a/gitignore-generator/gitignore.js
+++ b/gitignore-generator/gitignore.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { generateGitignore } = require('./lib/generate');
+const { listSupported } = require('./lib/technologies');
+
+function printUsage() {
+  console.error('Usage: node gitignore.js <technology> [technology...]');
+  console.error(`Supported technologies: ${listSupported().join(', ')}`);
+  console.error('Example: node gitignore.js node react vscode');
+}
+
+function main(argv) {
+  if (argv.length === 0) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const { content, included, unsupported } = generateGitignore(argv);
+
+  for (const name of unsupported) {
+    console.error(`Unsupported technology: ${name}`);
+  }
+
+  if (included.length === 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  const outputPath = path.join(process.cwd(), '.gitignore');
+  fs.writeFileSync(outputPath, content);
+
+  console.log(`.gitignore created for: ${included.join(', ')}`);
+}
+
+main(process.argv.slice(2));

--- a/gitignore-generator/lib/generate.js
+++ b/gitignore-generator/lib/generate.js
@@ -1,0 +1,55 @@
+const { resolveTechnology } = require('./technologies');
+
+function dedupeCaseInsensitive(names) {
+  const seen = new Set();
+  const result = [];
+
+  for (const name of names) {
+    const key = String(name).trim().toLowerCase();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      result.push(name);
+    }
+  }
+
+  return result;
+}
+
+function generateGitignore(technologyNames) {
+  const uniqueNames = dedupeCaseInsensitive(technologyNames);
+
+  const included = [];
+  const unsupported = [];
+  const sections = [];
+  const seenLines = new Set();
+
+  for (const name of uniqueNames) {
+    const tech = resolveTechnology(name);
+
+    if (!tech) {
+      unsupported.push(name);
+      continue;
+    }
+
+    included.push(tech.name);
+
+    const newLines = tech.content
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !seenLines.has(line));
+
+    for (const line of newLines) {
+      seenLines.add(line);
+    }
+
+    if (newLines.length > 0) {
+      sections.push(`# ${tech.name}\n${newLines.join('\n')}`);
+    }
+  }
+
+  const content = sections.length > 0 ? `${sections.join('\n\n')}\n` : '';
+
+  return { content, included, unsupported };
+}
+
+module.exports = { generateGitignore };

--- a/gitignore-generator/lib/technologies.js
+++ b/gitignore-generator/lib/technologies.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+
+const DISPLAY_NAMES = {
+  node: 'Node.js',
+  react: 'React',
+  nextjs: 'Next.js',
+  express: 'Express.js',
+  vscode: 'VS Code',
+  jetbrains: 'JetBrains IDEs',
+  python: 'Python',
+  docker: 'Docker',
+  laravel: 'Laravel',
+  flutter: 'Flutter',
+  android: 'Android',
+  go: 'Go',
+  rust: 'Rust',
+  java: 'Java',
+};
+
+const ALIASES = {
+  nodejs: 'node',
+  next: 'nextjs',
+  expressjs: 'express',
+  'vs-code': 'vscode',
+  intellij: 'jetbrains',
+  py: 'python',
+  golang: 'go',
+};
+
+function normalize(name) {
+  return String(name).trim().toLowerCase();
+}
+
+function toSlug(name) {
+  const normalized = normalize(name);
+  return ALIASES[normalized] || normalized;
+}
+
+function listSupported() {
+  return Object.keys(DISPLAY_NAMES);
+}
+
+function resolveTechnology(name) {
+  const slug = toSlug(name);
+
+  if (!DISPLAY_NAMES[slug]) {
+    return null;
+  }
+
+  const content = fs.readFileSync(path.join(TEMPLATES_DIR, `${slug}.txt`), 'utf8');
+
+  return {
+    slug,
+    name: DISPLAY_NAMES[slug],
+    content,
+  };
+}
+
+module.exports = {
+  resolveTechnology,
+  listSupported,
+};

--- a/gitignore-generator/templates/android.txt
+++ b/gitignore-generator/templates/android.txt
@@ -1,0 +1,10 @@
+*.apk
+*.aab
+*.ap_
+*.dex
+local.properties
+.gradle/
+build/
+captures/
+.externalNativeBuild/
+.cxx/

--- a/gitignore-generator/templates/docker.txt
+++ b/gitignore-generator/templates/docker.txt
@@ -1,0 +1,4 @@
+*.pid
+.docker/
+docker-compose.override.yml
+.env

--- a/gitignore-generator/templates/express.txt
+++ b/gitignore-generator/templates/express.txt
@@ -1,0 +1,9 @@
+node_modules/
+.env
+.env.local
+logs/
+*.log
+npm-debug.log*
+dist/
+build/
+coverage/

--- a/gitignore-generator/templates/flutter.txt
+++ b/gitignore-generator/templates/flutter.txt
@@ -1,0 +1,9 @@
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+*.g.dart
+*.freezed.dart

--- a/gitignore-generator/templates/go.txt
+++ b/gitignore-generator/templates/go.txt
@@ -1,0 +1,9 @@
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+vendor/
+go.work

--- a/gitignore-generator/templates/java.txt
+++ b/gitignore-generator/templates/java.txt
@@ -1,0 +1,8 @@
+*.class
+*.jar
+*.war
+*.ear
+target/
+build/
+.gradle/
+out/

--- a/gitignore-generator/templates/jetbrains.txt
+++ b/gitignore-generator/templates/jetbrains.txt
@@ -1,0 +1,5 @@
+.idea/
+*.iml
+*.iws
+out/
+.shelf/

--- a/gitignore-generator/templates/laravel.txt
+++ b/gitignore-generator/templates/laravel.txt
@@ -1,0 +1,13 @@
+vendor/
+node_modules/
+.env
+.env.backup
+.phpunit.result.cache
+storage/*.key
+storage/framework/cache/
+storage/framework/sessions/
+storage/framework/views/
+storage/logs/
+bootstrap/cache/
+public/hot
+public/storage

--- a/gitignore-generator/templates/nextjs.txt
+++ b/gitignore-generator/templates/nextjs.txt
@@ -1,0 +1,13 @@
+node_modules/
+.next/
+out/
+build/
+dist/
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.vercel
+next-env.d.ts
+*.tsbuildinfo

--- a/gitignore-generator/templates/node.txt
+++ b/gitignore-generator/templates/node.txt
@@ -1,0 +1,14 @@
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env
+.env.local
+.env.*.local
+dist/
+build/
+coverage/
+*.log
+.npm
+.node_repl_history

--- a/gitignore-generator/templates/python.txt
+++ b/gitignore-generator/templates/python.txt
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.eggs/
+.venv/
+venv/
+env/
+.env
+.mypy_cache/
+.pytest_cache/
+.tox/
+dist/
+build/
+*.log

--- a/gitignore-generator/templates/react.txt
+++ b/gitignore-generator/templates/react.txt
@@ -1,0 +1,12 @@
+node_modules/
+build/
+dist/
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+coverage/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/gitignore-generator/templates/rust.txt
+++ b/gitignore-generator/templates/rust.txt
@@ -1,0 +1,4 @@
+target/
+Cargo.lock
+**/*.rs.bk
+*.pdb

--- a/gitignore-generator/templates/vscode.txt
+++ b/gitignore-generator/templates/vscode.txt
@@ -1,0 +1,3 @@
+.vscode/
+*.code-workspace
+.history/

--- a/gitignore-generator/tests/cli.test.js
+++ b/gitignore-generator/tests/cli.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CLI_PATH = path.join(__dirname, '..', 'gitignore.js');
+
+function runCli(args, cwd) {
+  const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+}
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gitignore-cli-test-'));
+}
+
+test('creates a .gitignore file for valid technologies', () => {
+  const cwd = makeTempDir();
+  const result = runCli(['node', 'react'], cwd);
+
+  assert.equal(result.status, 0);
+  const written = fs.readFileSync(path.join(cwd, '.gitignore'), 'utf8');
+  assert.match(written, /# Node\.js/);
+  assert.match(written, /# React/);
+});
+
+test('prints usage and exits non-zero with no arguments', () => {
+  const cwd = makeTempDir();
+  const result = runCli([], cwd);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Usage:/);
+  assert.equal(fs.existsSync(path.join(cwd, '.gitignore')), false);
+});
+
+test('overwrites an existing .gitignore', () => {
+  const cwd = makeTempDir();
+  fs.writeFileSync(path.join(cwd, '.gitignore'), 'old-content-that-should-be-replaced\n');
+
+  const result = runCli(['python'], cwd);
+
+  assert.equal(result.status, 0);
+  const written = fs.readFileSync(path.join(cwd, '.gitignore'), 'utf8');
+  assert.doesNotMatch(written, /old-content-that-should-be-replaced/);
+  assert.match(written, /# Python/);
+});
+
+test('exits non-zero and writes nothing when all technologies are unsupported', () => {
+  const cwd = makeTempDir();
+  const result = runCli(['unknown'], cwd);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unsupported technology: unknown/);
+  assert.equal(fs.existsSync(path.join(cwd, '.gitignore')), false);
+});
+
+test('exits zero and writes valid rules when input is a mix of valid and invalid', () => {
+  const cwd = makeTempDir();
+  const result = runCli(['node', 'unknown'], cwd);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /Unsupported technology: unknown/);
+  const written = fs.readFileSync(path.join(cwd, '.gitignore'), 'utf8');
+  assert.match(written, /# Node\.js/);
+});

--- a/gitignore-generator/tests/generate.test.js
+++ b/gitignore-generator/tests/generate.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { generateGitignore } = require('../lib/generate');
+
+test('generates content for a single technology', () => {
+  const { content, included, unsupported } = generateGitignore(['node']);
+
+  assert.deepEqual(included, ['Node.js']);
+  assert.deepEqual(unsupported, []);
+  assert.match(content, /# Node\.js/);
+  assert.match(content, /node_modules\//);
+});
+
+test('merges multiple technologies without duplicate lines', () => {
+  const { content, included } = generateGitignore(['node', 'react']);
+
+  assert.deepEqual(included, ['Node.js', 'React']);
+
+  const lines = content.split('\n').filter((line) => line.length > 0 && !line.startsWith('#'));
+  const uniqueLines = new Set(lines);
+  assert.equal(lines.length, uniqueLines.size, 'expected no duplicate rule lines');
+});
+
+test('treats duplicate arguments as a single technology', () => {
+  const { content, included } = generateGitignore(['node', 'node', 'react']);
+
+  assert.deepEqual(included, ['Node.js', 'React']);
+  assert.equal(content.match(/# Node\.js/g).length, 1);
+});
+
+test('is case-insensitive when deduping and resolving', () => {
+  const { included } = generateGitignore(['Node', 'node', 'NODE']);
+  assert.deepEqual(included, ['Node.js']);
+});
+
+test('reports unsupported technologies and excludes them from content', () => {
+  const { content, included, unsupported } = generateGitignore(['node', 'unknown']);
+
+  assert.deepEqual(included, ['Node.js']);
+  assert.deepEqual(unsupported, ['unknown']);
+  assert.doesNotMatch(content, /unknown/);
+});
+
+test('returns empty content when nothing is supported', () => {
+  const { content, included, unsupported } = generateGitignore(['unknown']);
+
+  assert.equal(content, '');
+  assert.deepEqual(included, []);
+  assert.deepEqual(unsupported, ['unknown']);
+});

--- a/gitignore-generator/tests/technologies.test.js
+++ b/gitignore-generator/tests/technologies.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveTechnology, listSupported } = require('../lib/technologies');
+
+test('resolveTechnology returns content for a supported slug', () => {
+  const tech = resolveTechnology('node');
+  assert.equal(tech.slug, 'node');
+  assert.equal(tech.name, 'Node.js');
+  assert.match(tech.content, /node_modules\//);
+});
+
+test('resolveTechnology resolves aliases to the canonical slug', () => {
+  const tech = resolveTechnology('nodejs');
+  assert.equal(tech.slug, 'node');
+});
+
+test('resolveTechnology is case-insensitive', () => {
+  const tech = resolveTechnology('Node');
+  assert.equal(tech.slug, 'node');
+});
+
+test('resolveTechnology returns null for an unsupported technology', () => {
+  assert.equal(resolveTechnology('unknown'), null);
+});
+
+test('listSupported includes the required minimum set', () => {
+  const supported = listSupported();
+  const required = ['node', 'react', 'nextjs', 'express', 'vscode', 'jetbrains', 'python'];
+
+  for (const slug of required) {
+    assert.ok(supported.includes(slug), `expected ${slug} to be supported`);
+  }
+});


### PR DESCRIPTION
What was done

Adds a CLI (gitignore-generator/gitignore.js) that generates a .gitignore file by merging rules from one or more technologies, without duplicate entries.

node gitignore-generator/gitignore.js node react vscode

Supports Node.js, React, Next.js, Express.js, VS Code, JetBrains IDEs, Python, Docker, Laravel, Flutter, Android, Go, Rust, and Java, with aliases (nodejs, next, vs-code, etc.) and case-insensitive input.

Why it was done

Every new project requires manually searching for the right .gitignore per stack, which leads to incomplete files or committing sensitive files (.env, node_modules/). This CLI solves that locally, with no external dependencies.

How to test

node --test gitignore-generator/tests/*.test.js

Or manually:
cd /tmp && node <path>/gitignore-generator/gitignore.js node react vscode
cat .gitignore

Edge cases covered: no arguments (prints usage, exit 1), unsupported technology (Unsupported technology: X), duplicate arguments, and a mix of valid/invalid technologies.

Impact

- Affected areas: new gitignore-generator/ directory; root README.md ("Available Utilities" section)
- Breaking changes: no

References

- Closes #125