### PR TITLE
test(once): cover this-context preservation and argument forwarding

### DIFF
--- a/tests/once_test.js
+++ b/tests/once_test.js
@@ -12,3 +12,27 @@ test("once should only call function once", () => {
 
   expect(count).toBe(1);
 });
+
+test("once preserves the calling context (this)", () => {
+  const user = {
+    name: "Moeez",
+    greet: once(function () {
+      return this.name;
+    }),
+  };
+
+  expect(user.greet()).toBe("Moeez");
+});
+
+test("once forwards arguments and caches the first result", () => {
+  const obj = {
+    base: 10,
+    add: once(function (a, b) {
+      return this.base + a + b;
+    }),
+  };
+
+  expect(obj.add(1, 2)).toBe(13);
+  // Subsequent calls return the cached result, ignoring new arguments.
+  expect(obj.add(3, 4)).toBe(13);
+});


### PR DESCRIPTION
## Related Issue
Closes #143

## Description

The `once()` utility already preserves the calling context via `func.apply(this, args)`, but the test suite only verified that the wrapped function runs once. This adds two tests:

- **Context preservation**: an object method wrapped with `once()` returns `this.name` correctly when called as `user.greet()`.
- **Argument forwarding + caching**: confirms arguments reach the wrapped function on the first call and the first result is returned unchanged on subsequent calls (ignoring new arguments).

The implementation in `utils/once.js` is unchanged — these tests pin the behaviour the issue describes so a future refactor cannot silently drop the `this` binding or argument forwarding.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project code style
- [x] I have added tests/examples if applicable
- [x] I have linked the relevant issue number
- [x] My PR is self-contained and does not include unrelated changes