### PR TITLE
Fix groupBy to handle numeric/boolean keys and prevent prototype poll…

### DIFF
--- a/tests/groupBy.test.js
+++ b/tests/groupBy.test.js
@@ -32,3 +32,28 @@ const callbackUndefined = [
 console.log(groupBy(callbackUndefined, () => undefined));
 
 console.log(users);
+
+// Edge Cases
+
+// 1. Boolean keys
+const booleanItems = [
+  { name: "A", active: true },
+  { name: "B", active: false },
+  { name: "C", active: true }
+];
+console.log(groupBy(booleanItems, item => item.active));
+
+// 2. Numeric keys
+const numericItems = [
+  { 0: "A" },
+  { 0: "B" },
+  { 1: "C" }
+];
+console.log(groupBy(numericItems, 0));
+
+// 3. Prototype keys (should not overwrite existing prototype properties)
+const protoKeys = [
+  { key: "constructor", val: 1 },
+  { key: "__proto__", val: 2 }
+];
+console.log(groupBy(protoKeys, item => item.key));

--- a/utils/groupBy.js
+++ b/utils/groupBy.js
@@ -10,7 +10,8 @@ function groupBy(array, keyOrFn) {
     return {};
   }
 
-  if (typeof keyOrFn !== 'string' && typeof keyOrFn !== 'function') {
+  const isValidKey = ['string', 'number', 'boolean', 'symbol'].includes(typeof keyOrFn);
+  if (!isValidKey && typeof keyOrFn !== 'function') {
     return {};
   }
 
@@ -21,7 +22,7 @@ function groupBy(array, keyOrFn) {
 
     const normalizedKey = String(groupKey);
 
-    if (!result[normalizedKey]) {
+    if (!Object.prototype.hasOwnProperty.call(result, normalizedKey)) {
       result[normalizedKey] = [];
     }
 


### PR DESCRIPTION
## Description
This PR improves the `groupBy()` utility to correctly handle callback-generated keys. 

### Changes made:
- Added support for `boolean`, `number`, and `symbol` keys by updating type validations.
- Replaced direct object property access (`result[normalizedKey]`) with `Object.prototype.hasOwnProperty.call()` to prevent prototype pollution and avoid overwriting native properties like `constructor` or `__proto__`.
- Added test cases in `tests/groupBy.test.js` to ensure the correct handling of numeric keys, boolean keys, and prototype keys.
- Ensured all existing tests continue to pass.

Fixes #145