### PR TITLE
test: add unit tests for debounce this-context and argument forwarding

### DIFF
--- a/tests/debounce.test.js
+++ b/tests/debounce.test.js
@@ -1,0 +1,55 @@
+const debounce = require("../utils/debounce");
+
+jest.useFakeTimers();
+
+test("debounce delays function execution", () => {
+  let count = 0;
+  const increment = () => count++;
+  const debounced = debounce(increment, 300);
+
+  debounced();
+  expect(count).toBe(0);
+
+  jest.advanceTimersByTime(300);
+  expect(count).toBe(1);
+});
+
+test("debounce only calls the function once for rapid successive calls", () => {
+  let count = 0;
+  const increment = () => count++;
+  const debounced = debounce(increment, 300);
+
+  debounced();
+  debounced();
+  debounced();
+
+  jest.advanceTimersByTime(300);
+  expect(count).toBe(1);
+});
+
+test("debounce preserves the calling context (this)", () => {
+  const user = {
+    name: "Moeez",
+    greet: debounce(function () {
+      this.captured = this.name;
+    }, 300),
+  };
+
+  user.greet();
+  jest.advanceTimersByTime(300);
+
+  expect(user.captured).toBe("Moeez");
+});
+
+test("debounce forwards arguments correctly", () => {
+  let received;
+  const fn = (a, b) => {
+    received = a + b;
+  };
+  const debounced = debounce(fn, 300);
+
+  debounced(2, 3);
+  jest.advanceTimersByTime(300);
+
+  expect(received).toBe(5);
+});


### PR DESCRIPTION
Fixes #132

## What
Adds a full test suite for `debounce()` covering the behaviors called out
in the issue: preserving `this` context, forwarding arguments correctly,
delaying execution, and collapsing rapid successive calls into one.

## Investigation notes
I traced the issue's example through the current `./utils/debounce.js`
implementation and found it already correctly preserves `this` and
forwards arguments — no changes to the source were needed. The wrapper
captures the caller's `this` synchronously and applies it inside the
`setTimeout` callback, which handles the exact scenario described in
the issue.

I also found a second file, `./src/utils/debounce.js`, with a similar
(also correct) implementation. Neither file is currently `require`d
anywhere else in the repo. I left it untouched since I wasn't sure
which one is meant to be canonical for this issue — happy to remove it
as a duplicate, or dig further into a specific edge case, if you can
point me to one that's still broken.

## Changes
- Added `tests/debounce.test.js`, modeled on the existing
  `tests/once_test.js` pattern

## Testing
- `npx jest tests/debounce.test.js` → all 4 new tests pass
- `npx jest` (full suite) → no regressions